### PR TITLE
Update nbodymodule.f90

### DIFF
--- a/src/nbodymodule.f90
+++ b/src/nbodymodule.f90
@@ -15,7 +15,7 @@ real, parameter :: twopi = 2.0*pi
 !
 
 integer,parameter :: isnap = 10
-integer,parameter :: ilog = 2
+integer,parameter :: ilog = 22
 
 integer :: N,ibody,jbody,ix,snapshotcounter
 


### PR DESCRIPTION
Fortran 90 has a bug with setting ilog = 2. Changed it to 22.